### PR TITLE
Adds Wistia Video Support

### DIFF
--- a/embed_video/backends.py
+++ b/embed_video/backends.py
@@ -1,3 +1,12 @@
+from django.http import QueryDict
+from django.template.loader import render_to_string
+from django.utils.functional import cached_property
+from django.utils.safestring import mark_safe
+
+from .utils import import_by_path
+from .settings import EMBED_VIDEO_BACKENDS, EMBED_VIDEO_TIMEOUT, \
+    EMBED_VIDEO_YOUTUBE_DEFAULT_QUERY
+
 import re
 import sys
 import json
@@ -7,15 +16,6 @@ if sys.version_info.major == 3:
     import urllib.parse as urlparse
 else:
     import urlparse
-
-from django.http import QueryDict
-from django.template.loader import render_to_string
-from django.utils.functional import cached_property
-from django.utils.safestring import mark_safe
-
-from .utils import import_by_path
-from .settings import EMBED_VIDEO_BACKENDS, EMBED_VIDEO_TIMEOUT, \
-    EMBED_VIDEO_YOUTUBE_DEFAULT_QUERY
 
 
 class EmbedVideoException(Exception):
@@ -222,6 +222,9 @@ class VideoBackend(object):
 
         :type url: str
         """
+        print(url)
+        print(cls.re_detect)
+        print(cls.re_detect.match(url))
         return True if cls.re_detect.match(url) else False
 
     def get_code(self):
@@ -366,6 +369,55 @@ class VimeoBackend(VideoBackend):
 
     def get_thumbnail_url(self):
         return self.info.get('thumbnail_large')
+
+
+#  Wistia uses oEmbed which contains a lot of helpful info.
+class WistiaBackend(VideoBackend):
+    """
+    Backend for Wistia URLs.
+    """
+    # TODO: Revisit this, with whatever their embed code looks like and the pattern_url as well
+    re_detect = re.compile(r'https://(?P<domain>[a-z]+).wistia.com/medias/*', re.I)
+    re_code = re.compile(r'''wistia\.com/(medias/(.*/)?|deliveries/)(?P<code>[a-z0-9;:@?&%=+/\$_.-]+)''', re.I)  # regex is different in python.
+
+    pattern_url = '{protocol}://{domain}.wistia.com/medias/{code}'
+    pattern_info = '{protocol}://fast.wistia.net/oembed?url={protocol}%3A%2F%2F{domain}.wistia.com%2Fmedias%2F{code}&embedType=async'
+
+    pattern_thumbnail_url = '{protocol}://embed.wistia.com/{code}.jpeg?video_still_time=10'
+
+    @cached_property
+    def width(self):
+        """
+        :rtype: str
+        """
+        return self.info.get('width')
+
+    @cached_property
+    def height(self):
+        """
+        :rtype: str
+        """
+        return self.info.get('height')
+
+    def get_info(self):
+        try:
+            response = requests.get(
+                self.pattern_info.format(domain=self.domain, code=self.code, protocol=self.protocol), timeout=EMBED_VIDEO_TIMEOUT
+            )
+            return json.loads(response.text)[0]
+        except ValueError:
+            raise VideoDoesntExistException()
+
+    def get_thumbnail_url(self):
+        """
+        Returns thumbnail URL folded from :py:data:`pattern_thumbnail_url` and
+        parsed code.
+        :rtype: str
+        """
+        temp_thumbnail_url = self.pattern_thumbnail_url.format(code=self.code, protocol=self.protocol)
+        if(int(requests.head(temp_thumbnail_url).status_code) < 400):
+            return temp_thumbnail_url
+        return None
 
 
 class SoundCloudBackend(VideoBackend):

--- a/embed_video/settings.py
+++ b/embed_video/settings.py
@@ -4,6 +4,7 @@ from django.conf import settings
 EMBED_VIDEO_BACKENDS = getattr(settings, 'EMBED_VIDEO_BACKENDS', (
     'embed_video.backends.YoutubeBackend',
     'embed_video.backends.VimeoBackend',
+    'embed_video.backends.WistiaBackend',
     'embed_video.backends.SoundCloudBackend',
 ))
 """ :type: tuple[str] """

--- a/embed_video/tests/backends/tests_wistia.py
+++ b/embed_video/tests/backends/tests_wistia.py
@@ -1,0 +1,35 @@
+import requests
+from mock import patch
+from unittest import TestCase
+
+from . import BackendTestMixin
+from embed_video.backends import WistiaBackend, VideoDoesntExistException
+
+
+class WistiaBackendTestCase(BackendTestMixin, TestCase):
+
+    urls = (
+        # ('https://gxsc.wistia.com/medias/ed0lahzq9t', 'ed0lahzq9t'),
+        # ('https://gxsc.wistia.com/medias/ndfbdn2zi0', 'ndfbdn2zi0'),
+        # ('https://gxsc.wistia.com/medias/vcktuzuw5p', 'vcktuzuw5p'),
+        ('https://support.wistia.com/medias/26sk4lmiix', '26sk4lmiix'),  # This comes from the wistia docs
+        #  ('http://player.vimeo.com/video/72304002', '72304002'), used this as a test
+        # ('http://embed.wistia.com/deliveries/5413caeac5fdf4064a2f9eab5c10a0848e42f19f', '5413caeac5fdf4064a2f9eab5c10a0848e42f19f')
+    )
+
+    instance = WistiaBackend
+
+    def test_wistia_get_info_exception(self):
+        with self.assertRaises(VideoDoesntExistException):
+            backend = WistiaBackend('http://gxsc.wistia.com/123')
+            backend.get_info()
+
+    def test_get_thumbnail_url(self):
+        backend = WistiaBackend('http://embed.wistia.com/deliveries/5413caeac5fdf4064a2f9eab5c10a0848e42f19f')
+        self.assertEqual(backend.get_thumbnail_url(),
+                         'http://embed.wistia.com/deliveries/5413caeac5fdf4064a2f9eab5c10a0848e42f19f.jpeg?video_still_time=10')
+
+    @patch('embed_video.backends.EMBED_VIDEO_TIMEOUT', 0.000001)
+    def test_timeout_in_get_info(self):
+        backend = WistiaBackend('http://support.wistia.com/72304002')
+        self.assertRaises(requests.Timeout, backend.get_info)

--- a/embed_video/tests/backends/tests_wistia.py
+++ b/embed_video/tests/backends/tests_wistia.py
@@ -9,25 +9,21 @@ from embed_video.backends import WistiaBackend, VideoDoesntExistException
 class WistiaBackendTestCase(BackendTestMixin, TestCase):
 
     urls = (
-        # ('https://gxsc.wistia.com/medias/ed0lahzq9t', 'ed0lahzq9t'),
-        # ('https://gxsc.wistia.com/medias/ndfbdn2zi0', 'ndfbdn2zi0'),
-        # ('https://gxsc.wistia.com/medias/vcktuzuw5p', 'vcktuzuw5p'),
         ('https://support.wistia.com/medias/26sk4lmiix', '26sk4lmiix'),  # This comes from the wistia docs
-        #  ('http://player.vimeo.com/video/72304002', '72304002'), used this as a test
-        # ('http://embed.wistia.com/deliveries/5413caeac5fdf4064a2f9eab5c10a0848e42f19f', '5413caeac5fdf4064a2f9eab5c10a0848e42f19f')
+        ('https://home.wistia.com/medias/342jss6yh5', '342jss6yh5'),
     )
 
     instance = WistiaBackend
 
     def test_wistia_get_info_exception(self):
         with self.assertRaises(VideoDoesntExistException):
-            backend = WistiaBackend('http://gxsc.wistia.com/123')
+            backend = WistiaBackend('http://support.wistia.com/123')
             backend.get_info()
 
     def test_get_thumbnail_url(self):
-        backend = WistiaBackend('http://embed.wistia.com/deliveries/5413caeac5fdf4064a2f9eab5c10a0848e42f19f')
+        backend = WistiaBackend('https://home.wistia.com/medias/342jss6yh5')
         self.assertEqual(backend.get_thumbnail_url(),
-                         'http://embed.wistia.com/deliveries/5413caeac5fdf4064a2f9eab5c10a0848e42f19f.jpeg?video_still_time=10')
+                         'https://embed-ssl.wistia.com/deliveries/7fc8174a908ad1d349196405671e0fbdaa1e84eb.jpg?image_crop_resized=960x540')
 
     @patch('embed_video.backends.EMBED_VIDEO_TIMEOUT', 0.000001)
     def test_timeout_in_get_info(self):

--- a/embed_video/tests/django_settings.py
+++ b/embed_video/tests/django_settings.py
@@ -19,6 +19,7 @@ EMBED_VIDEO_BACKENDS = (
     'embed_video.backends.YoutubeBackend',
     'embed_video.backends.VimeoBackend',
     'embed_video.backends.SoundCloudBackend',
+    'embed_video.backends.WistiaBackend',
     'embed_video.tests.backends.tests_custom_backend.CustomBackend',
 )
 


### PR DESCRIPTION
# What Is this?
https://wistia.com/ provides a video service similar to that of youtube, or vimeo. The added benefit being analytics, and a full set of features to customize the look of the video, and how it behaves.

# Why add this?
Wistia is becoming a popular go-to for businesses that want to have video's embedded on their site. This Link: https://wistia.com/blog/wistia-vs-youtube provides a pretty good run-down of why businesses would choose wistia over youtube.

# How to test?
Simply run the nose tests supplied, and to test usability simply use the example project provided, and upload one of the available wistia video urls in place of a vimeo or youtube video. 
Public wistia videos are difficult to find, but I have provided two links in the test_wistia_video_embed file. 


Cheers!
/cc @chris-erickson